### PR TITLE
Make sure polygon rings are complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,14 @@ module.exports = function(feature, tolerance, highQuality) {
       var simpleRing = simplify(pts, tolerance, highQuality).map(function(coords) {
         return [coords.x, coords.y];
       });
+      for (var i = 0; i < 4; i++) {
+        if (!simpleRing[i]) simpleRing.push(simpleRing[0])
+      }
+      if (
+        (simpleRing[simpleRing.length-1][0] !== simpleRing[0][0]) ||
+        (simpleRing[simpleRing.length-1][1] !== simpleRing[0][1])) {
+        simpleRing.push(simpleRing[0])
+      }
       poly.coordinates.push(simpleRing);
     });
     return simpleFeature(poly, feature.properties);

--- a/test/fixtures/out/polygon_out.geojson
+++ b/test/fixtures/out/polygon_out.geojson
@@ -1,1 +1,1 @@
-{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-75.40347388749522,39.11245],[-75.51527029981442,39.11245]]]},"properties":{"elevation":25}}
+{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-75.40347388749522,39.11245],[-75.51527029981442,39.11245],[-75.40347388749522,39.11245],[-75.40347388749522,39.11245]]]},"properties":{"elevation":25}}


### PR DESCRIPTION
This makes sure that all polygon rings have at least 4 coordinates, and that the first coordinate and last coordinate in a ring are equal. Fixes cases where a polygon is oversimplified to a single point/line, such as in https://github.com/Turfjs/turf/issues/247